### PR TITLE
Fix pg97 typo

### DIFF
--- a/DimensionalityReduction/DimensionalityReduction.tex
+++ b/DimensionalityReduction/DimensionalityReduction.tex
@@ -211,7 +211,7 @@ One way to do this is similar to the informal `elbow' method described for K-Mea
 
 Another way to do this is to consider how much variance we wish to preserve in our data. Each principal component is associated with an eigenvalue $\lambda_{d}$ that indicates what proportion of the variance that principal component is responsible for in our data set. Then the fraction of variance retained from our data set if we choose to keep $D'$ principal components is given by:
 \begin{equation} \label{variance-retention}
-    \text{retained variance} = \frac{\sum_{d'=1}^{D'} \lambda_{d'}}{\sum_{d=1}^{D} \lambda{d}}
+    \text{retained variance} = \frac{\sum_{d'=1}^{D'} \lambda_{d'}}{\sum_{d=1}^{D} \lambda_{d}}
 \end{equation}
 For different applications, there may be different levels of acceptable variance retention, which can help us decide how many principal components to keep.
 

--- a/DimensionalityReduction/DimensionalityReduction.tex
+++ b/DimensionalityReduction/DimensionalityReduction.tex
@@ -154,7 +154,6 @@ Rewriting this in terms of matrix notation we have that:
 We can further simplify this:
 \begin{align*}
     \sigma^{2}_{\textbf{w}} &= \frac{1}{n} \textbf{w}^{T}\textbf{X}^{T} \textbf{X} \textbf{w} \\
-    \sigma^{2}_{\textbf{w}} &= \frac{1}{n} \textbf{w}^{T}\textbf{X}^{T} \textbf{X} \textbf{w} \\
     \sigma^{2}_{\textbf{w}} &= \textbf{w}^{T} \frac{\textbf{X}^{T}\textbf{X}}{n} \textbf{w} \\
     \sigma^{2}_{\textbf{w}} &= \textbf{w}^{T} \textbf{S} \textbf{w} \\
 \end{align*}


### PR DESCRIPTION
Removed first line of simplification as it is the same as the second line. Fixes issue #17. Screenshot of error on page 97 attached:

![image](https://user-images.githubusercontent.com/43184042/112729100-d6b6ac80-8f00-11eb-88a0-2c00fcbf393c.png)
